### PR TITLE
typo

### DIFF
--- a/chp/1.rst
+++ b/chp/1.rst
@@ -146,7 +146,7 @@ prelude模块中的类型，值和函数是默认直接可用的，在使用之�
         precedence parsing error
             cannot mix `(+)' [infixl 6] and prefix `-' [infixl 6] in the same infix expression
 
-如果需要在一个中缀操作符附近使用一元操作符，则需要将一元操作符以及其操作数包含的括号内。
+如果需要在一个中缀操作符附近使用一元操作符，则需要将一元操作符以及其操作数包含在括号内。
 
 ::
 


### PR DESCRIPTION
把
> 将一元操作符以及其操作数包含**的**括号内

改为
>将一元操作符以及其操作数包含**在**括号内

句子主干为「将 a 包含在 b 内」。